### PR TITLE
A few optimizations to reduce the Closure Compiled size

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+# WARNING: the following assumes that the variable "x" is not used in jsfxr() _after_ the Closure Compiler
+
 # Compress JavaScript
 java -jar compiler.jar --compilation_level ADVANCED_OPTIMIZATIONS --js jsfxr.js | \
-	tr -d '\n\r' > jsfxr.min.js
+	tr -d '\n\r' |
+	sed -r 's!"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789\+/"!x!g' | \
+	sed -r 's!"data:audio/wav;base64,"!"data:audio/wav;base64,",x="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"!g' > jsfxr.min.js
 
 # Check file size
 du -b jsfxr.min.js

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Compress JavaScript
-java -jar compiler.jar --compilation_level ADVANCED_OPTIMIZATIONS --js jsfxr.js --js_output_file jsfxr.min.js
+java -jar compiler.jar --compilation_level ADVANCED_OPTIMIZATIONS --js jsfxr.js | \
+	tr -d '\n\r' > jsfxr.min.js
 
 # Check file size
 du -b jsfxr.min.js

--- a/jsfxr.js
+++ b/jsfxr.js
@@ -17,6 +17,7 @@
  *
  * @author Thomas Vian
  */
+/** @constructor */
 function SfxrParams() {
   //--------------------------------------------------------------------------
   //
@@ -94,6 +95,7 @@ function SfxrParams() {
  *
  * @author Thomas Vian
  */
+/** @constructor */
 function SfxrSynth() {
   // All variables are kept alive through function closures
 

--- a/jsfxr.js
+++ b/jsfxr.js
@@ -170,9 +170,10 @@ function SfxrSynth() {
     // Calculating the length is all that remained here, everything else moved somewhere
     _envelopeLength0 = p['b']  * p['b']  * 100000;
     _envelopeLength1 = p['c'] * p['c'] * 100000;
-    _envelopeLength2 = p['e']   * p['e']   * 100000 + 10;
+    _envelopeLength2 = p['e']   * p['e']   * 100000 + 12;
     // Full length of the volume envelop (and therefore sound)
-    return _envelopeLength0 + _envelopeLength1 + _envelopeLength2 | 0;
+    // Make sure the length can be divided by 3 so we will not need the padding "==" after base64 encode
+    return ((_envelopeLength0 + _envelopeLength1 + _envelopeLength2) / 3 | 0) * 3;
   }
 
   /**
@@ -477,6 +478,5 @@ window['jsfxr'] = function(settings) {
     var a = data[i] << 16 | data[i + 1] << 8 | data[i + 2];
     output += base64Characters[a >> 18] + base64Characters[a >> 12 & 63] + base64Characters[a >> 6 & 63] + base64Characters[a & 63];
   }
-  i -= used;
-  return output.slice(0, output.length - i) + '=='.slice(0, i);
+  return output;
 }

--- a/jsfxr.js
+++ b/jsfxr.js
@@ -155,7 +155,7 @@ function SfxrSynth() {
       _dutySweep  = -p['o'] * .00005;
     }
 
-    _changeAmount = p['l'] > 0 ? 1 - p['l'] * p['l'] * .9 : 1 + p['l'] * p['l'] * 10;
+    _changeAmount =  1 + p['l'] * p['l'] * (p['l'] > 0 ? -.9 : 10);
     _changeTime   = 0;
     _changeLimit  = p['m'] == 1 ? 0 : (1 - p['m']) * (1 - p['m']) * 20000 + 32;
   }
@@ -389,9 +389,9 @@ function SfxrSynth() {
             break;
           case 2: // Sine wave (fast and accurate approx)
             _pos = _phase / _periodTemp;
-            _pos = _pos > .5 ? (_pos - 1) * 6.28318531 : _pos * 6.28318531;
-            _sample = _pos < 0 ? 1.27323954 * _pos + .405284735 * _pos * _pos : 1.27323954 * _pos - .405284735 * _pos * _pos;
-            _sample = _sample < 0 ? .225 * (_sample *-_sample - _sample) + _sample : .225 * (_sample * _sample - _sample) + _sample;
+            _pos = (_pos > .5 ? _pos - 1 : _pos) * 6.28318531;
+            _sample = 1.27323954 * _pos + .405284735 * _pos * _pos (_pos < 0 ? 1 : -1);
+            _sample = .225 * ((_sample < 0 ? -1 : 1) * _sample * _sample  - _sample) + _sample;
             break;
           case 3: // Noise
             _sample = _noiseBuffer[Math.abs(_phase * 32 / _periodTemp | 0)];


### PR DESCRIPTION
I have added a few optimizations to save 282 bytes (10%) on the Closure Compiler processed output, also I have added jsdoc annotations to mark the constructors so the Compiler knows it is safe to use "this".

Please see note on 83d30df about that change.
